### PR TITLE
Add parrow locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ see `test/test1.ijs`
 ##### TODO
 * [x] Figure out how to formalize data/arrow.ijs as an add-on
 * [x] `install 'github:interregna/JArrow@main'`
-* [ ] Drop functions into a jarrow locale and link entry points up to z locale.
+* [x] Drop functions into a `parrow` locale and link entry points up to z locale.
 * [ ] Document functions: Print a manual / help dialog.
 * [ ] J for buffers
 * [ ] J for errors

--- a/arrow.ijs
+++ b/arrow.ijs
@@ -1,4 +1,5 @@
 NB. init
+cocurrent 'parrow'
 
 lib =: >@((3&{.)@(TAB&cut)&.>)@(LF&cut)
 ret =: 0&{::
@@ -1447,3 +1448,9 @@ writeParquet=: {{
 writeParquetFromTable=: {{
   'table writeOptions' =. y
 }}
+NB. ====================
+NB. Expose public interface in z locale
+
+readParquetTable_z_=: readParquetTable_parrow_
+readsParquetTable_z_=: readsParquetTable_parrow_
+readParquetSchema_z_=: readParquetSchema_parrow_

--- a/arrow.jproj
+++ b/arrow.jproj
@@ -20,3 +20,4 @@ src/data/value.ijs
 src/io/io.ijs
 src/ipc/ipc.ijs
 src/arrow.ijs
+src/public.ijs

--- a/src/init.ijs
+++ b/src/init.ijs
@@ -1,4 +1,5 @@
 NB. init
+cocurrent 'parrow'
 
 lib =: >@((3&{.)@(TAB&cut)&.>)@(LF&cut)
 ret =: 0&{::

--- a/src/public.ijs
+++ b/src/public.ijs
@@ -1,0 +1,6 @@
+NB. ====================
+NB. Expose public interface in z locale
+
+readParquetTable_z_=: readParquetTable_parrow_
+readsParquetTable_z_=: readsParquetTable_parrow_
+readParquetSchema_z_=: readParquetSchema_parrow_

--- a/test/test1.ijs
+++ b/test/test1.ijs
@@ -11,6 +11,8 @@ NB. copy test parquet files to ~temp if they're not already there
 }}''
 
 load ProjPath,'/arrow.ijs'
+coinsert 'parrow'
+
 t1path =. TempPath,'test1.parquet'
 tp1 =. readParquet t1path
 echo readSchemaString tp1


### PR DESCRIPTION
Tidy the addin functions away in its own locale. Use `parrow` because the `j` prefix is reserved for use by Jsoftware "provided" locales.

Exposes some higher level verbs in the `z` locale. For access to all functions in the current locale use: `coinsert 'parrow'` to add the `parrow` locale to the search path for the current locale.